### PR TITLE
Write pure React components as functions

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[Makefile]
+indent_style = tab

--- a/src/views/block_view.js
+++ b/src/views/block_view.js
@@ -3,10 +3,7 @@ import styles from '../../assets/stylesheets/styles.scss'
 
 const BLOCK_SIZE = 23
 
-export default class BlockView extends React.PureComponent {
-  render () {
-    const {position, color} = this.props.block
+export default ({block: {position, color}}) => {
     const style = {bottom: position.y * BLOCK_SIZE, left: position.x * BLOCK_SIZE}
     return <li className={styles[color]} style={style} />
-  }
 }

--- a/src/views/block_view.js
+++ b/src/views/block_view.js
@@ -4,6 +4,6 @@ import styles from '../../assets/stylesheets/styles.scss'
 const BLOCK_SIZE = 23
 
 export default ({block: {position, color}}) => {
-    const style = {bottom: position.y * BLOCK_SIZE, left: position.x * BLOCK_SIZE}
-    return <li className={styles[color]} style={style} />
+  const style = {bottom: position.y * BLOCK_SIZE, left: position.x * BLOCK_SIZE}
+  return <li className={styles[color]} style={style} />
 }

--- a/src/views/game_over_view.js
+++ b/src/views/game_over_view.js
@@ -4,12 +4,12 @@ import classnames from 'classnames'
 import styles from '../../assets/stylesheets/styles.scss'
 
 export default ({bus}) =>
-      <div className={classnames(styles.modal, styles.row)}>
-        <div className={classnames(styles.container, styles['align-self-center'])}>
-          <h1>Game Over</h1>
-          <footer>
-            <button onClick={() => bus.emit('restart')}>Play Again</button>
-            <SocialView />
-          </footer>
-        </div>
-      </div>
+  <div className={classnames(styles.modal, styles.row)}>
+    <div className={classnames(styles.container, styles['align-self-center'])}>
+      <h1>Game Over</h1>
+      <footer>
+        <button onClick={() => bus.emit('restart')}>Play Again</button>
+        <SocialView />
+      </footer>
+    </div>
+  </div>

--- a/src/views/game_over_view.js
+++ b/src/views/game_over_view.js
@@ -3,11 +3,7 @@ import SocialView from './social_view'
 import classnames from 'classnames'
 import styles from '../../assets/stylesheets/styles.scss'
 
-export default class GameOverView extends React.PureComponent {
-  render () {
-    const bus = this.props.bus
-
-    return (
+export default ({bus}) =>
       <div className={classnames(styles.modal, styles.row)}>
         <div className={classnames(styles.container, styles['align-self-center'])}>
           <h1>Game Over</h1>
@@ -17,6 +13,3 @@ export default class GameOverView extends React.PureComponent {
           </footer>
         </div>
       </div>
-    )
-  }
-}

--- a/src/views/game_view.js
+++ b/src/views/game_view.js
@@ -3,9 +3,7 @@ import TetrionView from './tetrion_view'
 import TetrominoView from './tetromino_view'
 import styles from '../../assets/stylesheets/styles.scss'
 
-export default class GameView extends React.PureComponent {
-  render () {
-    const {bus, game} = this.props
+export default ({bus, game}) => {
     let message
 
     if (game.reward && game.reward.message) {
@@ -45,5 +43,4 @@ export default class GameView extends React.PureComponent {
         </aside>
       </div>
     )
-  }
 }

--- a/src/views/game_view.js
+++ b/src/views/game_view.js
@@ -4,43 +4,43 @@ import TetrominoView from './tetromino_view'
 import styles from '../../assets/stylesheets/styles.scss'
 
 export default ({bus, game}) => {
-    let message
+  let message
 
-    if (game.reward && game.reward.message) {
-      message = game.reward.message
-    }
+  if (game.reward && game.reward.message) {
+    message = game.reward.message
+  }
 
-    return (
-      <div className={styles.game}>
-        <aside className={styles.left}>
-          <div className={styles.panel}>
-            <h6>Hold</h6>
-            {game.tetrion.holdPiece ? <TetrominoView tetromino={game.tetrion.holdPiece} /> : null}
-          </div>
+  return (
+    <div className={styles.game}>
+      <aside className={styles.left}>
+        <div className={styles.panel}>
+          <h6>Hold</h6>
+          {game.tetrion.holdPiece ? <TetrominoView tetromino={game.tetrion.holdPiece} /> : null}
+        </div>
 
-          <div className={styles.progress}>
-            <h6>Score</h6>
-            <p>{game.progress.score}</p>
-            <h6>Lines</h6>
-            <p>{game.progress.lines}</p>
-            <h6>Level</h6>
-            <p>{game.progress.level}</p>
-          </div>
-        </aside>
+        <div className={styles.progress}>
+          <h6>Score</h6>
+          <p>{game.progress.score}</p>
+          <h6>Lines</h6>
+          <p>{game.progress.lines}</p>
+          <h6>Level</h6>
+          <p>{game.progress.level}</p>
+        </div>
+      </aside>
 
-        <TetrionView message={message} tetrion={game.tetrion} />
+      <TetrionView message={message} tetrion={game.tetrion} />
 
-        <aside className={styles.right}>
-          <div className={styles.panel}>
-            <h6>Next</h6>
-            {game.tetrion.nextPiece ? <TetrominoView tetromino={game.tetrion.nextPiece} /> : null}
-          </div>
+      <aside className={styles.right}>
+        <div className={styles.panel}>
+          <h6>Next</h6>
+          {game.tetrion.nextPiece ? <TetrominoView tetromino={game.tetrion.nextPiece} /> : null}
+        </div>
 
-          <nav>
-            <a href='#' onClick={() => bus.emit('pause')}><span className={styles['icon-help']} /></a>
-            <a href='#' onClick={() => bus.emit('mute')}><span className={game.muted ? styles['icon-bell-slash'] : styles['icon-bell']} /></a>
-          </nav>
-        </aside>
-      </div>
-    )
+        <nav>
+          <a href='#' onClick={() => bus.emit('pause')}><span className={styles['icon-help']} /></a>
+          <a href='#' onClick={() => bus.emit('mute')}><span className={game.muted ? styles['icon-bell-slash'] : styles['icon-bell']} /></a>
+        </nav>
+      </aside>
+    </div>
+  )
 }

--- a/src/views/help_view.js
+++ b/src/views/help_view.js
@@ -3,62 +3,62 @@ import SocialView from './social_view'
 import styles from '../../assets/stylesheets/styles.scss'
 
 export default ({bus}) =>
-      <div className={styles.modal}>
-        <div className={styles.container}>
-          <h1>Tetris</h1>
+  <div className={styles.modal}>
+    <div className={styles.container}>
+      <h1>Tetris</h1>
 
-          <h2>How to Play</h2>
+      <h2>How to Play</h2>
 
-          <p>The goal of Tetris is to score as many points as possible by
-          clearing horizontal lines of blocks. The player must rotate, move, and
-          drop the falling tetriminos inside the playfield. Lines are cleared when
-          they are filled with blocks and have no empty spaces.</p>
+      <p>The goal of Tetris is to score as many points as possible by
+      clearing horizontal lines of blocks. The player must rotate, move, and
+      drop the falling tetriminos inside the playfield. Lines are cleared when
+      they are filled with blocks and have no empty spaces.</p>
 
-          <p>As lines are cleared, the level increases and tetriminos fall
-          faster, making the game progressively more challenging. If the blocks
-          land above the top of the playfield, then the game is over.</p>
+      <p>As lines are cleared, the level increases and tetriminos fall
+      faster, making the game progressively more challenging. If the blocks
+      land above the top of the playfield, then the game is over.</p>
 
-          <dl>
-            <dt>LEFT</dt>
-            <dd>Move the falling tetromino left.</dd>
+      <dl>
+        <dt>LEFT</dt>
+        <dd>Move the falling tetromino left.</dd>
 
-            <dt>RIGHT</dt>
-            <dd>Move the falling tetromino right.</dd>
+        <dt>RIGHT</dt>
+        <dd>Move the falling tetromino right.</dd>
 
-            <dt>DOWN</dt>
-            <dd>Move the falling tetromino down (soft drop).</dd>
+        <dt>DOWN</dt>
+        <dd>Move the falling tetromino down (soft drop).</dd>
 
-            <dt>Z</dt>
-            <dd>Rotate the falling tetromino left.</dd>
+        <dt>Z</dt>
+        <dd>Rotate the falling tetromino left.</dd>
 
-            <dt>X/UP</dt>
-            <dd>Rotate the falling tetromino right.</dd>
+        <dt>X/UP</dt>
+        <dd>Rotate the falling tetromino right.</dd>
 
-            <dt>C</dt>
-            <dd>Store the falling tetromino for later use.</dd>
+        <dt>C</dt>
+        <dd>Store the falling tetromino for later use.</dd>
 
-            <dt>SPACE</dt>
-            <dd>Drop the falling tetromino to the bottom of the playfield and lock it immediately (hard drop).</dd>
+        <dt>SPACE</dt>
+        <dd>Drop the falling tetromino to the bottom of the playfield and lock it immediately (hard drop).</dd>
 
-            <dt>RETURN</dt>
-            <dd>Drop the falling tetromino to the bottom of the playfield, but don't lock it (firm drop).</dd>
+        <dt>RETURN</dt>
+        <dd>Drop the falling tetromino to the bottom of the playfield, but don't lock it (firm drop).</dd>
 
-            <dt>H</dt>
-            <dd>Toggle the help screen.</dd>
+        <dt>H</dt>
+        <dd>Toggle the help screen.</dd>
 
-            <dt>M</dt>
-            <dd>Toggle the game audio.</dd>
-          </dl>
+        <dt>M</dt>
+        <dd>Toggle the game audio.</dd>
+      </dl>
 
-          <h2>Credits</h2>
+      <h2>Credits</h2>
 
-          <p>Made with love by <a href='https://joshbassett.info'>Josh Bassett</a>, 2018.</p>
+      <p>Made with love by <a href='https://joshbassett.info'>Josh Bassett</a>, 2018.</p>
 
-          <p>Special thanks to <a href='https:/kouky.org'>Michael Koukoullis</a> for inspiring me to work on Tetris in the first place. This work is based on a project we started, but never finished.</p>
+      <p>Special thanks to <a href='https:/kouky.org'>Michael Koukoullis</a> for inspiring me to work on Tetris in the first place. This work is based on a project we started, but never finished.</p>
 
-          <footer>
-            <p><button onClick={() => bus.emit('pause')}>Resume</button></p>
-            <SocialView />
-          </footer>
-        </div>
-      </div>
+      <footer>
+        <p><button onClick={() => bus.emit('pause')}>Resume</button></p>
+        <SocialView />
+      </footer>
+    </div>
+  </div>

--- a/src/views/help_view.js
+++ b/src/views/help_view.js
@@ -2,11 +2,7 @@ import React from 'react'
 import SocialView from './social_view'
 import styles from '../../assets/stylesheets/styles.scss'
 
-export default class HelpView extends React.PureComponent {
-  render () {
-    const bus = this.props.bus
-
-    return (
+export default ({bus}) =>
       <div className={styles.modal}>
         <div className={styles.container}>
           <h1>Tetris</h1>
@@ -66,6 +62,3 @@ export default class HelpView extends React.PureComponent {
           </footer>
         </div>
       </div>
-    )
-  }
-}

--- a/src/views/playfield_view.js
+++ b/src/views/playfield_view.js
@@ -3,6 +3,6 @@ import React from 'react'
 import styles from '../../assets/stylesheets/styles.scss'
 
 export default ({playfield: {blocks}}) =>
-      <ul className={styles.playfield}>
-        {blocks.map(block => <BlockView key={block.id} block={block} />)}
-      </ul>
+  <ul className={styles.playfield}>
+    {blocks.map(block => <BlockView key={block.id} block={block} />)}
+  </ul>

--- a/src/views/playfield_view.js
+++ b/src/views/playfield_view.js
@@ -2,13 +2,7 @@ import BlockView from './block_view'
 import React from 'react'
 import styles from '../../assets/stylesheets/styles.scss'
 
-export default class PlayfieldView extends React.PureComponent {
-  render () {
-    const {blocks} = this.props.playfield
-    return (
+export default ({playfield: {blocks}}) =>
       <ul className={styles.playfield}>
         {blocks.map(block => <BlockView key={block.id} block={block} />)}
       </ul>
-    )
-  }
-}

--- a/src/views/root_view.js
+++ b/src/views/root_view.js
@@ -5,8 +5,8 @@ import HelpView from './help_view'
 import React from 'react'
 
 export default ({bus, state: {game}}) =>
-      <React.Fragment>
-        <GameView bus={bus} game={game} />
-        {game.paused ? <HelpView bus={bus} /> : null}
-        {game.over ? <GameOverView bus={bus} /> : null}
-      </React.Fragment>
+  <React.Fragment>
+    <GameView bus={bus} game={game} />
+    {game.paused ? <HelpView bus={bus} /> : null}
+    {game.over ? <GameOverView bus={bus} /> : null}
+  </React.Fragment>

--- a/src/views/root_view.js
+++ b/src/views/root_view.js
@@ -4,16 +4,9 @@ import GameOverView from './game_over_view'
 import HelpView from './help_view'
 import React from 'react'
 
-export default class RootView extends React.PureComponent {
-  render () {
-    const {bus, state: {game}} = this.props
-
-    return (
+export default ({bus, state: {game}}) =>
       <React.Fragment>
         <GameView bus={bus} game={game} />
         {game.paused ? <HelpView bus={bus} /> : null}
         {game.over ? <GameOverView bus={bus} /> : null}
       </React.Fragment>
-    )
-  }
-}

--- a/src/views/social_view.js
+++ b/src/views/social_view.js
@@ -6,8 +6,8 @@ const FACEBOOK_URL = 'http://www.facebook.com/sharer.php?u=https%3A%2F%2Ftetris.
 const GITHUB_URL = 'https://github.com/nullobject/tetris'
 
 export default () =>
-      <nav className={styles.social}>
-        <a href={TWITTER_URL} target='_blank'><span className={styles['icon-twitter']} /></a>
-        <a href={FACEBOOK_URL} target='_blank'><span className={styles['icon-facebook']} /></a>
-        <a href={GITHUB_URL} target='_blank'><span className={styles['icon-github']} /></a>
-      </nav>
+  <nav className={styles.social}>
+    <a href={TWITTER_URL} target='_blank'><span className={styles['icon-twitter']} /></a>
+    <a href={FACEBOOK_URL} target='_blank'><span className={styles['icon-facebook']} /></a>
+    <a href={GITHUB_URL} target='_blank'><span className={styles['icon-github']} /></a>
+  </nav>

--- a/src/views/social_view.js
+++ b/src/views/social_view.js
@@ -5,14 +5,9 @@ const TWITTER_URL = 'https://twitter.com/intent/tweet?text=Wanna%20play%20some%2
 const FACEBOOK_URL = 'http://www.facebook.com/sharer.php?u=https%3A%2F%2Ftetris.joshbassett.info'
 const GITHUB_URL = 'https://github.com/nullobject/tetris'
 
-export default class HelpView extends React.PureComponent {
-  render () {
-    return (
+export default () =>
       <nav className={styles.social}>
         <a href={TWITTER_URL} target='_blank'><span className={styles['icon-twitter']} /></a>
         <a href={FACEBOOK_URL} target='_blank'><span className={styles['icon-facebook']} /></a>
         <a href={GITHUB_URL} target='_blank'><span className={styles['icon-github']} /></a>
       </nav>
-    )
-  }
-}

--- a/src/views/tetrion_view.js
+++ b/src/views/tetrion_view.js
@@ -11,17 +11,17 @@ const Message = ({text, ...props}) => (
 )
 
 export default ({message, tetrion}) => {
-    const {playfield, fallingPiece, ghostPiece} = tetrion
+  const {playfield, fallingPiece, ghostPiece} = tetrion
 
-    return (
-      <div className={styles.tetrion}>
-        <PlayfieldView playfield={playfield} />
-        {fallingPiece ? <TetrominoView falling tetromino={fallingPiece} /> : null}
-        {ghostPiece ? <TetrominoView ghost tetromino={ghostPiece} /> : null}
+  return (
+    <div className={styles.tetrion}>
+      <PlayfieldView playfield={playfield} />
+      {fallingPiece ? <TetrominoView falling tetromino={fallingPiece} /> : null}
+      {ghostPiece ? <TetrominoView ghost tetromino={ghostPiece} /> : null}
 
-        <TransitionGroup>
-          {message ? <Message key={message.id} text={message.text} /> : null}
-        </TransitionGroup>
-      </div>
-    )
+      <TransitionGroup>
+        {message ? <Message key={message.id} text={message.text} /> : null}
+      </TransitionGroup>
+    </div>
+  )
 }

--- a/src/views/tetrion_view.js
+++ b/src/views/tetrion_view.js
@@ -10,9 +10,7 @@ const Message = ({text, ...props}) => (
   </Transition>
 )
 
-export default class TetrionView extends React.PureComponent {
-  render () {
-    const {message, tetrion} = this.props
+export default ({message, tetrion}) => {
     const {playfield, fallingPiece, ghostPiece} = tetrion
 
     return (
@@ -26,5 +24,4 @@ export default class TetrionView extends React.PureComponent {
         </TransitionGroup>
       </div>
     )
-  }
 }

--- a/src/views/tetromino_view.js
+++ b/src/views/tetromino_view.js
@@ -3,11 +3,11 @@ import React from 'react'
 import classnames from 'classnames'
 import styles from '../../assets/stylesheets/styles.scss'
 
-export default ({tetromino: {shape, blocks}}) => {
+export default ({ghost, tetromino: {shape, blocks}}) => {
   const className = classnames(
     styles.tetromino,
     styles[`shape-${shape.toLowerCase()}`],
-    {[styles.ghostPiece]: this.props.ghost}
+    {[styles.ghostPiece]: ghost}
   )
   return (
     <ul className={className}>

--- a/src/views/tetromino_view.js
+++ b/src/views/tetromino_view.js
@@ -4,14 +4,14 @@ import classnames from 'classnames'
 import styles from '../../assets/stylesheets/styles.scss'
 
 export default ({tetromino: {shape, blocks}}) => {
-    const className = classnames(
-      styles.tetromino,
-      styles[`shape-${shape.toLowerCase()}`],
-      {[styles.ghostPiece]: this.props.ghost}
-    )
-    return (
-      <ul className={className}>
-        {blocks.map(block => <BlockView key={block.id} block={block} />)}
-      </ul>
-    )
+  const className = classnames(
+    styles.tetromino,
+    styles[`shape-${shape.toLowerCase()}`],
+    {[styles.ghostPiece]: this.props.ghost}
+  )
+  return (
+    <ul className={className}>
+      {blocks.map(block => <BlockView key={block.id} block={block} />)}
+    </ul>
+  )
 }

--- a/src/views/tetromino_view.js
+++ b/src/views/tetromino_view.js
@@ -3,9 +3,7 @@ import React from 'react'
 import classnames from 'classnames'
 import styles from '../../assets/stylesheets/styles.scss'
 
-export default class TetrominoView extends React.PureComponent {
-  render () {
-    const {shape, blocks} = this.props.tetromino
+export default ({tetromino: {shape, blocks}}) => {
     const className = classnames(
       styles.tetromino,
       styles[`shape-${shape.toLowerCase()}`],
@@ -16,5 +14,4 @@ export default class TetrominoView extends React.PureComponent {
         {blocks.map(block => <BlockView key={block.id} block={block} />)}
       </ul>
     )
-  }
 }


### PR DESCRIPTION
This lets us indent less.

It comes at the cost of not being allowed to put the component name in the 'export' clause. Possible workarounds:

(a) Declare functional component with `const`, then `export` it

```js
const C = props => ...
export default C
```

But this means we have to put the declaration and export on separate lines.

(b) Declare functional component using `function`

```js
export default function C(props) {
   ...
}
```

But this means we can't use the `=>` shorthand return syntax from arrow functions.

Of course, modules who import a default export don't actually look at whatever name you give the default export in the module itself (if you even give it one). But it could be argued that naming it in the module itself is desired for documentation purposes.